### PR TITLE
`Edit as YAML` buttons are broken in all resource edit page.

### DIFF
--- a/shell/components/CruResource.vue
+++ b/shell/components/CruResource.vue
@@ -320,7 +320,9 @@ export default {
 
     async createResourceYaml(modifiers, resource = this.resource) {
       // Required to populate yaml comments and default values
-      await this.schema?.fetchResourceFields();
+      if (this.schema?.fetchResourceFields && typeof this.schema.fetchResourceFields === 'function') {
+        await this.schema?.fetchResourceFields();
+      }
 
       if ( typeof this.generateYaml === 'function' ) {
         return this.generateYaml.apply(this, resource);
@@ -337,7 +339,9 @@ export default {
 
     async showPreviewYaml() {
       // Required to populate yaml comments and default values
-      await this.schema?.fetchResourceFields();
+      if (this.schema?.fetchResourceFields && typeof this.schema.fetchResourceFields === 'function') {
+        await this.schema?.fetchResourceFields();
+      }
 
       if ( this.applyHooks ) {
         try {


### PR DESCRIPTION

### Summary

`Edit as YAML` button is broken in all resource edit page.
 
<img width="1496" alt="Screenshot 2024-10-01 at 6 22 17 PM" src="https://github.com/user-attachments/assets/e0ba6060-d07d-4491-a594-9654753e20ef">


After Fix

<img width="1496" alt="image" src="https://github.com/user-attachments/assets/d8e33fd7-75bb-4a7d-806e-f489cb8608c3">
